### PR TITLE
fix: Update UChicago AF docs for EOS access

### DIFF
--- a/tier3docs/doma/DataSharing/uchicago/uc_cern_work.md
+++ b/tier3docs/doma/DataSharing/uchicago/uc_cern_work.md
@@ -1,5 +1,22 @@
 ## Access to CERN-EOS from UChicago
 
+!!! warning
+
+    `/eos` is only mounted on the interactive (`login`) nodes. To access from worker nodes (e.g. condor jobs), we recommend the use of `xrootd` such as
+
+    ```
+    root://eosuser.cern.ch//eos/user/d/dschrute/file.txt
+    ```
+
+    or via `xrdcp` inside your job
+
+    ```
+    xrdcp root://eosuser.cern.ch//eos/user/d/dschrute/file.txt .
+    xrdcp -r root://eosuser.cern.ch//eos/user/d/dschrute/many_files/ .
+    ```
+
+    as long as you [export your CERN Kerberos ticket](README.md#cern-kerberos-ticket) to your HTCondor jobs.
+
 The ways to list, write and read files on CERN EOS, documented
 [here](https://twiki.cern.ch/twiki/bin/view/AtlasComputing/ATLASStorageAtCERN#EOS_storage_system),
 still work at UChicago.


### PR DESCRIPTION
This deprecates the `setup-eos` function in favor of using `/eos` for most everything.

```
gstark@af:~$ setup-eos
⚠️  The 'setup-eos' script is DEPRECATED and no longer required.

➡️  To access EOS, simply run:
    kinit <username>@CERN.CH
    ls /eos/atlas
    ls /eos/user/g/gstark

See https://usatlas.readthedocs.io/projects/af-docs/en/latest/doma/DataSharing/uchicago/ for more details.
```

<img width="1522" height="1638" alt="Screenshot 2025-10-14 at 09 53 24" src="https://github.com/user-attachments/assets/a16a5447-a5f3-4a58-b290-2b02e65cdb07" />

