### PR TITLE
fix: admonition rendering, switch to inline code block for readability

### DIFF
--- a/docs/faqs_tips.md
+++ b/docs/faqs_tips.md
@@ -21,8 +21,8 @@ To avoid the above trouble, you can:
 ### Sharing the same kerberos token among the home clusters
 
 By default, the kerberos token is cached locally on each individual machine, and
-you have to run `kinit` each time on a different node. If those machines share the
-same home directory, you can define the envvar `KRB5CCNAME` to
+you have to run `kinit` each time on a different node. If those machines share
+the same home directory, you can define the envvar `KRB5CCNAME` to
 `$HOME/krb5cc_$(id -u)` prior to running `kinit`. So you would have a valid
 kerberos token on other machines too.
 
@@ -42,13 +42,13 @@ used for multiple kerberos pricipals. That is:
 export KRB5CCNAME=DIR:$HOME/.krb5cc
 ```
 
-Please note the prefix `DIR:` before the directory name. And you need create
-the directory `$HOME/.krb5cc` in advance.
+Please note the prefix `DIR:` before the directory name. And you need create the
+directory `$HOME/.krb5cc` in advance.
 
 ### How to set up python3 env from CVMFS?
 
-Run `showVersions python` after the ALRB setup (that is, running
-`setupATLAS`). It will show the available python versions on CVMFS.
+Run `showVersions python` after the ALRB setup (that is, running `setupATLAS`).
+It will show the available python versions on CVMFS.
 
 Then you can pick up one suitable for you, says, `3.8.8-x86_64-centos7`. So you
 can run `lsetup "python 3.8.8-x86_64-centos7"` to set up that python3.

--- a/docs/faqs_tips.md
+++ b/docs/faqs_tips.md
@@ -10,48 +10,48 @@ after ssh login to CERN lxplus machines.
 /usr/bin/xauth:  timeout in locking authority file /afs/cern.ch/user/y/yesw/.Xauthority
 ```
 
-And it is very annoying that you have to run "kinit" again after ssh login.
+And it is very annoying that you have to run `kinit` again after ssh login.
 
 To avoid the above trouble, you can:
 
-- either add the option **"-k"** to the ssh command.
-- or add **"GSSAPIDelegateCredentials yes"** into ~/.ssh/config on the local
+- either add the option `-k` to the ssh command.
+- or add `GSSAPIDelegateCredentials yes` into `~/.ssh/config` on the local
   computer.
 
 ### Sharing the same kerberos token among the home clusters
 
 By default, the kerberos token is cached locally on each individual machine, and
-you have to run kinit each time on a different node. If those machines share the
-same home directory, you can define the envvar **KRB5CCNAME** to
-**$HOME/krb5cc\_`id -u`** prior to running **kinit**. So you would have a valid
+you have to run `kinit` each time on a different node. If those machines share the
+same home directory, you can define the envvar `KRB5CCNAME` to
+`$HOME/krb5cc_$(id -u)` prior to running `kinit`. So you would have a valid
 kerberos token on other machines too.
 
 For example, once you have obtained a valid CERN kerberos on one BNL attsub
 machine, you can also access CERN EOS on other attsub machines without running
-"kinit" again.
+`kinit` again.
 
 ### Sharing one envvar KRB5CCNAME among multiple kerberos principals
 
-The envvar **KRB5CCNAME** points to a file, it could only hold one kerberos
+The envvar `KRB5CCNAME` points to a file, it could only hold one kerberos
 prinpical.
 
 However, you can define it to point to a directory instead, then it could be
 used for multiple kerberos pricipals. That is:
 
-```
-  export KRB5CCNAME=DIR:$HOME/.krb5cc
+```sh
+export KRB5CCNAME=DIR:$HOME/.krb5cc
 ```
 
-Please note the prefix **"DIR:"** before the directory name. And you need create
-the directory **$HOME/.krb5cc** in advance.
+Please note the prefix `DIR:` before the directory name. And you need create
+the directory `$HOME/.krb5cc` in advance.
 
 ### How to set up python3 env from CVMFS?
 
-Run **showVersions python** after the ALRB setup (that is, running
-_setupATLAS_). It will show the available python versions on CVMFS.
+Run `showVersions python` after the ALRB setup (that is, running
+`setupATLAS`). It will show the available python versions on CVMFS.
 
-Then you can pick up one suitable for you, says, _3.8.8-x86_64-centos7_. So you
-can run **lsetup "python 3.8.8-x86_64-centos7"** to set up that python3.
+Then you can pick up one suitable for you, says, `3.8.8-x86_64-centos7`. So you
+can run `lsetup "python 3.8.8-x86_64-centos7"` to set up that python3.
 
 ### How to set up Rucio with python3?
 
@@ -60,9 +60,9 @@ python3?
 
 You can run the following:
 
-```
-  export RUCIO_PYTHONBIN=python3
-  lsetup rucio
+```sh
+export RUCIO_PYTHONBIN=python3
+lsetup rucio
 ```
 
 ### How to transfer QR code from Google Authenticator to other devices?
@@ -88,7 +88,7 @@ Authenticator, then add the secret code into other devices in the following:
 4. Call
    [this script on github](https://github.com/scito/extract_otp_secret_keys):
 
-```
+```sh
 python extract_otp_secret_keys.py -p example_export.txt
 ```
 
@@ -437,6 +437,7 @@ pkill -f my_script.py
 pkill -u $USER -f "jupyter"
 ```
 
+<!-- prettier-ignore -->
 !!! warning "Be Careful with pkill"
 
     `pkill` can terminate multiple processes at once. Always double-check what
@@ -447,7 +448,4 @@ pkill -u $USER -f "jupyter"
     pgrep -u $USER -f "pattern"
     # Then kill:
     pkill -u $USER -f "pattern"
-
-```
-
-```
+    ```


### PR DESCRIPTION
Fixes broken rendering of code block in admonition:
https://usatlas.github.io/af-docs/faqs_tips/#finding-your-processes

Also switches to consistent use of code blocks for commands and other strings.
