### PR TITLE
docs(ai): add <your-servername> to NRP example MCP config URL

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -204,7 +204,7 @@ to NRP and register the Jupyter MCP server:
             "command": "npx",
             "args": [
                 "mcp-remote",
-                "https://<YOUR_JUPYTERHUB_URL>/user/<your-username>/proxy/3001/mcp?token=<YOUR_JUPYTER_TOKEN>",
+                "https://<YOUR_JUPYTERHUB_URL>/user/<your-username>/<your-servername>/proxy/3001/mcp?token=<YOUR_JUPYTER_TOKEN>",
                 "--transport",
                 "http-only"
             ]


### PR DESCRIPTION
## Summary
Fixes the MCP URL in the Step 2 config block of the NRP + Jupyter MCP example so it includes the `<your-servername>` path segment.

Before:
```
https://<YOUR_JUPYTERHUB_URL>/user/<your-username>/proxy/3001/mcp?token=<YOUR_JUPYTER_TOKEN>
```
After:
```
https://<YOUR_JUPYTERHUB_URL>/user/<your-username>/<your-servername>/proxy/3001/mcp?token=<YOUR_JUPYTER_TOKEN>
```

This matches the URL template already shown in Step 3 (`.../user/<your-username>/<server-name>/proxy/3001/mcp`), which the config block was inconsistent with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)