### PR TITLE
docs(uchicago): fix pixi feature/environment workflow in jupyter docs

### DIFF
--- a/docs/uchicago/jupyter.md
+++ b/docs/uchicago/jupyter.md
@@ -73,19 +73,24 @@ documentation, see the
 
 You can install additional packages directly from your notebook with
 [`pixi`](https://pixi.prefix.dev/latest/). The `ml_platform` image organizes
-packages under features. For ML-related packages, use the `ml` feature (`-f ml`)
-and install them with the `ml` environment (`-e ml`). If you are not using a
-GPU-node, you can use the `mlcpu` environment which has the same set of packages
-without the `cuda` system requirement.
+packages under features. ML-related packages live in the `mlbase` feature
+(`-f mlbase` / `--feature mlbase`), which is shared by the `ml` and `mlcpu`
+environments. If you are not using a GPU-node, you can use the `mlcpu`
+environment which has the same set of packages without the `cuda` system
+requirement.
 
 **Example**: installing the GPU-version of `pytorch` along with `torchvision`
 and `xgboost` available on [conda-forge](https://conda-forge.org/packages/), you
 can run the following inside the notebook
 
 ```bash
-pixi add -f ml pytorch-gpu torchvision xgboost
-pixi install -e ml
+!pixi add pytorch-gpu torchvision xgboost --feature mlbase
+!pixi lock
 ```
+
+Then restart the kernel. The `!` prefix runs the command directly from a
+notebook cell; you can also open a terminal in JupyterLab and run the same
+commands without the `!`.
 
 For more advanced pixi usage, including custom environments and
 multi-environment support, see the [pixi](#pixi) section below.
@@ -190,17 +195,20 @@ incrementally or don't have an existing environment file.
 **Example: Creating a custom analysis feature:**
 
 ```bash
-# Create a new feature with core packages
-pixi add -f analysis numpy pandas matplotlib scipy
-
-# Add more packages as needed
-pixi add -f analysis uproot awkward hist
+# Create a new feature with core packages, including pixi-kernel
+!pixi add -f analysis numpy pandas matplotlib scipy uproot awkward hist pixi-kernel
 
 # Specify Python version if needed
-pixi add -f analysis "python>=3.11"
+!pixi add -f analysis "python>=3.11"
+```
 
-# Register the kernel
-pixi add -f analysis pixi-kernel
+Creating a feature does not automatically create a matching environment or
+kernel — you must register one explicitly, combining as many features as you
+need:
+
+```bash
+!pixi project environment add debug -f mlbase -f analysis
+!pixi lock
 ```
 
 You can also combine packages from different channels:
@@ -210,10 +218,16 @@ You can also combine packages from different channels:
 pixi add -f ml-custom -c pytorch -c conda-forge pytorch torchvision
 pixi add -f ml-custom scikit-learn xgboost
 pixi add -f ml-custom pixi-kernel
+pixi project environment add ml-custom -f ml-custom
+pixi lock
 ```
 
-Once created, use the feature as a kernel following the same steps described in
-the "Using your custom kernel in JupyterLab" section above.
+Once created, restart the kernel so the new environment (e.g. `debug`) shows up
+in the property inspector, then follow the same steps described in "Using your
+custom kernel in JupyterLab" above to select it, save the notebook, and restart
+the kernel again. The first time you switch to a newly created environment, pixi
+has to build it from scratch, which can hang for up to a minute while it
+installs all the packages — this is expected and only happens once.
 
 ### Managing Environments
 

--- a/docs/uchicago/jupyter.md
+++ b/docs/uchicago/jupyter.md
@@ -17,21 +17,11 @@ notebook:
 2. You can request 1 to 16 CPU cores.
 3. You can request 1 to 32 GB of memory.
 4. You can request 0 to 7 GPU instances.
-5. A notebook can have lifetime of up to 72 hours (1 to 168 hours).
+5. A notebook can have lifetime of up to 72 hours.
 6. You can select a GPU model based on its memory size. If you request a GPU,
    please make sure the GPU is available, by clicking on the icon next to GPU
    memory.
 7. You can choose a Docker image from the dropdown.
-
-## Resource Limitations
-
-- You can request 1 to 16 CPU cores.
-- You can request 1 to 32 GB of memory.
-- You can request 0 to 7 GPU instances.
-- A notebook can have lifetime of up to 72 hours.
-- You can select a GPU model based on its memory size. If you request a GPU,
-  please make sure the GPU is available, by clicking on the icon next to GPU
-  memory.
 
 ## Selecting GPU memory and instances
 
@@ -63,7 +53,6 @@ platform that includes:
 - `ml_platform-cpu:YYYY.MM` - Specific (older) release versions
 - `ml_platform-gpu:latest` - Latest stable version (recommended)
 - `ml_platform-gpu:YYYY.MM` - Specific (older) release versions
-- `ml_platform:YYYY.MM` - Specific (older) release versions
 
 For the complete list of packages, version information, and detailed
 documentation, see the
@@ -122,7 +111,7 @@ JupyterLab.
 
 **Understanding pixi features and environments:**
 
-- A **feature** is a named collection of packages (e.g., `ml`, `data-science`)
+- A **feature** is a named collection of packages (e.g., `data-science`, `nlp`)
 - An **environment** can combine multiple features together
 - Multiple environments can point to the same features in different combinations
 - This gives you full control over your dependencies, even more than conda/pip
@@ -248,10 +237,10 @@ pixi list -e my-env
 
 ```bash
 # Update specific packages in a feature
-pixi update -f ml pytorch torchvision
+pixi update -f mlbase pytorch torchvision
 
 # Update all packages in a feature
-pixi update -f ml
+pixi update -f mlbase
 
 # Update all packages in all environments
 pixi update
@@ -291,7 +280,7 @@ pixi install -e my-env
 Choose the right approach for your needs to keep your environments manageable
 and maintainable:
 
-**When to use the simple approach** (add to `ml` or `mlcpu` feature):
+**When to use the simple approach** (add to the `mlbase` feature):
 
 - You need just a few additional packages
 - Packages are compatible with the existing `ml` or `mlcpu` environment
@@ -402,7 +391,7 @@ du -sh ~/.pixi
 # Remove unused features by editing pixi.toml and running
 pixi install
 
-# Consider using the shared ml environment for common packages
+# Consider using the shared mlbase feature for common packages
 ```
 
 **Problem: Import is slow or hangs**

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,6 +18,8 @@ exclude = [
     "https://www.npmjs.com/", # 403
     "https://.*.servicex.af.uchicago.edu/", # 503
     "https://twiki.cern.ch/", # Timeouts...
+    "https://atlas-lgdm.cern.ch/LocalDisk_Usage/USER/RequestFormUsage/", # timeout, emailed Mayuko, waiting on response
+    "https://atlas-jupyter.sdcc.bnl.gov/", # timeout, see https://github.com/usatlas/af-docs/issues/132
 ]
 
 insecure = true


### PR DESCRIPTION
## Summary

Fixes inaccurate pixi instructions in the UChicago JupyterLab docs
(`docs/uchicago/jupyter.md`) for installing packages into a feature and
for creating a new environment/kernel.

- **Installing Additional Packages**: the ML-related packages actually
  live under the `mlbase` feature (shared by the `ml` and `mlcpu`
  environments), not a feature literally named `ml`. Replaced the
  `pixi install -e ml` step with `pixi lock` + a kernel restart, which is
  what's actually required to pick up new packages.
- **Creating Features from Scratch**: creating a feature does not
  automatically register a matching environment/kernel. Added the
  missing `pixi project environment add <name> -f <feature1> -f <feature2>`
  step, plus `pixi lock`, kernel restart to select it, save, and restart
  again. Also notes the first switch to a newly created environment can
  hang for up to a minute while pixi builds it.

Verified against a real UChicago JupyterLab session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
